### PR TITLE
make training faster again

### DIFF
--- a/dataset/data.py
+++ b/dataset/data.py
@@ -85,6 +85,7 @@ class TenhouIterableDataset(IterableDataset):
     def __init__(
         self,
         data_dir,
+        exclude_files,
         mode='discard',
         target_length=1,
         shuffle=True,
@@ -92,6 +93,7 @@ class TenhouIterableDataset(IterableDataset):
     ):
         super().__init__()
         self.data_dir = data_dir
+        self.exclude_files = exclude_files
         self.mode = mode
         self.target_length = target_length
         self.transform = transform
@@ -100,6 +102,8 @@ class TenhouIterableDataset(IterableDataset):
         self.func_name = f'parse_{mode}_data'  # e.g. parse_discard_data
 
     def _sample_generator_for_file(self, data_file):
+        if data_file in self.exclude_files:
+            return
         try:
             full_path = os.path.join(self.data_dir, data_file)
             playback = TenhouData(full_path)

--- a/dataset/data.py
+++ b/dataset/data.py
@@ -8,6 +8,16 @@ from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import IterableDataset
 from dataset.tenhou import TenhouData
 
+def collate_fn_discard(batch):
+    features = []
+    labels = []
+    for (f, lb) in batch:
+        features.append(f)
+        labels.append(lb)
+    features = torch.from_numpy(np.array(features)).float()
+    labels = torch.from_numpy(np.array(labels))
+    labels = labels // 4
+    return features, labels
 
 def process_data(one_batch, label_trans=None):
     features = []

--- a/sl_train/train_discard_model.py
+++ b/sl_train/train_discard_model.py
@@ -4,7 +4,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 
 from model.models import DiscardModel
-from dataset.data import TenhouDataset, process_data, collate_fn_discard
+from dataset.data import TenhouDataset, TenhouIterableDataset, process_data, collate_fn_discard
 
 import torch
 from torch.optim import Adam

--- a/sl_train/train_discard_model.py
+++ b/sl_train/train_discard_model.py
@@ -4,7 +4,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 
 from model.models import DiscardModel
-from dataset.data import process_data, collate_fn_discard
+from dataset.data import TenhouDataset, process_data, collate_fn_discard
 
 import torch
 from torch.optim import Adam

--- a/sl_train/train_discard_model.py
+++ b/sl_train/train_discard_model.py
@@ -1,13 +1,17 @@
 import os
-import torch
-from torch.optim import Adam
 import argparse
-import wandb
-from torch.nn import CrossEntropyLoss
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+
 from model.models import DiscardModel
-from dataset.data import TenhouDataset, process_data
+from dataset.data import process_data, collate_fn_discard
+
+import torch
+from torch.optim import Adam
+from torch.utils.data import DataLoader
+from torch.nn import CrossEntropyLoss
+import wandb
+import tqdm
 
 
 @torch.no_grad()
@@ -59,13 +63,25 @@ epochs = args.epochs
 os.makedirs(f'output/{mode}-model/checkpoints', exist_ok=True)
 max_acc = 0
 global_step = 0
+# patched dataset and loader
+dataset = TenhouIterableDataset(
+    data_dir='data',
+    exclude_files=set(test_set.data_files),  # exclude testing set
+    mode='discard',
+    target_length=2,
+    shuffle=True
+)
+train_loader = DataLoader(
+    dataset,
+    batch_size=512,
+    num_workers=4,
+    collate_fn=collate_fn_discard,
+    pin_memory=True,
+    prefetch_factor=10
+)
 for epoch in range(epochs):
-    while len(train_set) > 0:
-        data = train_set()
-        if len(data) == 0:
-            break
-        features, labels = process_data(data, label_trans=lambda x: x // 4)
-        features, labels = features.to(device), labels.to(device)
+    for features, labels in tqdm.tqdm(train_loader):
+        features, labels = features.to(device, non_blocking=True), labels.to(device, non_blocking=True)
         output = model(features)
         loss = loss_fcn(output, labels)
         optim.zero_grad()


### PR DESCRIPTION
训练速度有点慢，所以加了个wrapper，我发现dataset不是很规律，一个文件可能坏了，可能有>=1盘对局

暂时只给discard train改，其他mode和testing没动，看`nvidia-smi dmon`输出，sm/mem利用率有些提升，功率也上去了。

`collate_fn_discard`也可以是`functools.partial(process_data, label_trans=lambda x: x//4)`

before, main
![before](https://github.com/user-attachments/assets/5f456cf8-7bdc-43ff-8496-48796bc52d53)

after, batch size 128
![after-128](https://github.com/user-attachments/assets/0e3d08f0-6dd3-4f2a-bb5f-d18cdad3e4ea)

after, batch size 512
![after-512](https://github.com/user-attachments/assets/9f17231f-1e4d-43dc-b7ae-5fb76a2815a2)
